### PR TITLE
Only show values in the log for timer adjustments

### DIFF
--- a/cli/log.js
+++ b/cli/log.js
@@ -37,7 +37,11 @@ function format ({ key, value }) {
     chalk.bold(id)
   ].join(' ')
 
-  return [ label, formatValue(parseValue(value)) ]
+  const formattedValue = event === ADJUST_TIMER
+    ? formatValue(parseValue(value))
+    : undefined
+
+  return [ label, formattedValue ]
     .filter(data => typeof data !== 'undefined')
     .join(' ') + EOL
 }


### PR DESCRIPTION
Other events now have `0` stored as the value, but adjustments
are the only event that it's relevant to show the value for.